### PR TITLE
Fix hiera crashing if there is no :redis: section present in hiera.yaml 

### DIFF
--- a/lib/hiera/backend/redis_backend.rb
+++ b/lib/hiera/backend/redis_backend.rb
@@ -16,7 +16,7 @@ class Hiera
         
         # config overrides default values
         options.each_key do |k|
-          options[k] = Config[:redis][k] if Config[:redis].has_key?(k)
+          options[k] = Config[:redis][k] if Config[:redis].is_a?(Hash) && Config[:redis].has_key?(k)
         end
 
         @redis = Redis.new(options)


### PR DESCRIPTION
If we have no :redis: section in hiera.yaml (e.g. we are using the default settings) we receive a crash while accessing hiera-redis backend:

```
# hiera foo
/var/lib/gems/1.8/gems/hiera-redis-0.2.1/lib/hiera/backend/redis_backend.rb:20:in `initialize': undefined method `has_key?' for nil:NilClass (NoMethodError)
        from /var/lib/gems/1.8/gems/hiera-redis-0.2.1/lib/hiera/backend/redis_backend.rb:18:in `each_key'
        from /var/lib/gems/1.8/gems/hiera-redis-0.2.1/lib/hiera/backend/redis_backend.rb:18:in `initialize'
        from /var/lib/gems/1.8/gems/hiera-0.3.0.25/lib/hiera/backend.rb:168:in `new'
        from /var/lib/gems/1.8/gems/hiera-0.3.0.25/lib/hiera/backend.rb:168:in `lookup'
        from /var/lib/gems/1.8/gems/hiera-0.3.0.25/lib/hiera/backend.rb:166:in `each'
        from /var/lib/gems/1.8/gems/hiera-0.3.0.25/lib/hiera/backend.rb:166:in `lookup'
        from /var/lib/gems/1.8/gems/hiera-0.3.0.25/lib/hiera.rb:65:in `lookup'
        from /usr/local/bin/hiera:211
```

This commit fixes that (however does not produce any warnings as I'm not sure they are needed).

As a workaround if you need not alter any settings for accessing redis you can add the following line to hiera.yaml:

```
:redis: {}
```

but it is still missing from docs then.
