### PR TITLE
added an option not to raise errors when Redis server is unavailable

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ In hiera.yaml, the following options can be defined if needed:
   :db: 1
   :host: db.example.com
   :path: /tmp/redis.sock
+  :soft_connection_failure: true   # Return nil if Redis server is unavailable
+                                   # instead of raising exception
 </pre>
 
 If used, path takes a higher priority over port/host values.
@@ -34,6 +36,7 @@ default values:
 * host: localhost
 * path: nil
 * db: 0
+* soft_connection_failure: false
 
 Install
 =======


### PR DESCRIPTION
Currently the backend crashes if it cannot connect to Redis server.

Now there is an option of `soft_connection_failure` in config which makes the backend return `nil` instead of crashing in that case. Current default behaviour is protected so you need not make any changes in your config after upgrading.

The name for the key is the best I could invent so if you have any ideas how to name it more appropriately don't hesitate to rename it.
